### PR TITLE
New feedback form

### DIFF
--- a/docassemble/MassAccess/data/questions/feedback.yml
+++ b/docassemble/MassAccess/data/questions/feedback.yml
@@ -7,16 +7,18 @@ metadata:
   short title: Feedback
 ---
 code: |
-  al_feedback_form_title = "CourtFormsOnline Feedback Form"  
+  al_feedback_form_title = "CourtFormsOnline Feedback Form"
 ---
 code: |
   # This email will be used ONLY if there is no valid GitHub config
-  al_error_email = "massaccess@suffolk.edu"  
+  al_error_email = "massaccess@suffolk.edu"
 ---
 template: al_how_to_get_legal_help
+subject: Do you need more help?
 content: |
   If you need more help, these are free resources:
-  - For help with a non-criminal legal problem in Massachusetts, use the 
-  [Massachusetts Legal Resource Finder](http://masslegalhelp.org/find-legal-aid)
-  - If your income is low enough, try the [Mass Legal Answers Online](http://masslao.org/) website where volunteer lawyers answer questions
-  about your personal civil legal problems.
+
+  - For help with a non-criminal legal problem in Massachusetts, use the
+    [Massachusetts Legal Resource Finder](http://masslrf.org/en/home)
+  - If your income is low enough, try the [Mass Legal Answers Online](http://mass.freelegalanswers.org) website, where volunteer lawyers answer questions
+    about your personal civil legal problems.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MassAccess',
       url='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALMassachusetts>=0.1.0', 'docassemble.GithubFeedbackForm>=0.1.3'],
+      install_requires=['docassemble.ALMassachusetts>=0.1.0', 'docassemble.GithubFeedbackForm>=0.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MassAccess/', package='docassemble.MassAccess'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MassAccess',
       url='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALMassachusetts>=0.1.2', 'docassemble.GithubFeedbackForm==0.2.0b1'],
+      install_requires=['docassemble.ALMassachusetts>=0.1.2', 'docassemble.GithubFeedbackForm>=0.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MassAccess/', package='docassemble.MassAccess'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.MassAccess',
       url='https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALMassachusetts>=0.1.0', 'docassemble.GithubFeedbackForm>=0.2.0'],
+      install_requires=['docassemble.ALMassachusetts>=0.1.2', 'docassemble.GithubFeedbackForm==0.2.0b1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/MassAccess/', package='docassemble.MassAccess'),
      )


### PR DESCRIPTION
With https://github.com/SuffolkLITLab/docassemble-GithubFeedbackForm on 0.2.0 on production, the `feedback.yml` needs to be updated. These changes add a `subject` to the help template (which is shown in the collapsible template now), and improves the mako display, which wasn't working correctly inside of the collapsible template.

Here's what this interview looks like now: 
![Screenshot from 2022-09-12 14-36-11](https://user-images.githubusercontent.com/6252212/189730774-63edc6d6-cea7-461b-bb96-a89e1f42864f.png)

Here's what it looks like with these changes:
![Screenshot from 2022-09-12 14-41-33](https://user-images.githubusercontent.com/6252212/189731317-af8fc3ce-3230-4494-858c-dc31d7650c9a.png)

Hadn't merged this yet because the Feedback form wasn't released as 0.2.0 yet.
