### PR TITLE
Restrict new accounts created to SRLs

### DIFF
--- a/docassemble/MassAccess/data/questions/efile-account-interview.yml
+++ b/docassemble/MassAccess/data/questions/efile-account-interview.yml
@@ -7,7 +7,18 @@ include:
 metadata:
   title: |
     eFileMA Account Management
+  short title: |
+    efileMA
 ---
 code: |
   jurisdiction_id = 'massachusetts'
 ---
+variable name: account_action_list
+data: !!omap
+  - register: "Create an eFileMA account"
+  - reset_user_password: "Reset your eFileMA password"
+  - self_resend_activation: "Resend eFileMA activation email"
+---
+variable name: account_registration_choices
+data: !!omap
+  - INDIVIDUAL: Self-represented user


### PR DESCRIPTION
Firms cause some specific issues with the court codes and our interviews. Specifically, the MA court codes say that if you're a firm user, you are required to attaching a filing attorney to each filing (the `FilingFilingAttorneyView` datafield code). This is something we don't currently handle or have a comprehend-able UI for.

Since our interviews aren't made for firms anyway, we can restrict their creation here, so no one will accidentally or intentionally create a firm account.

Code from https://github.com/SuffolkLITLab/docassemble-ILAOEfile/blob/main/docassemble/ILAOEfile/data/questions/efile-account-interview.yml, and tested here as well.