### PR TITLE
Fix DABuild

### DIFF
--- a/docassemble/MassAccess/data/questions/theme_test.yml
+++ b/docassemble/MassAccess/data/questions/theme_test.yml
@@ -25,10 +25,10 @@ mandatory: true
 code:
   text_field
 ---
+id: theme-test
 question: Theme test
 fields:
   - Text field: text_field
-  - no label: no_label
   - Textarea: textarea
     input type: area
   - Label above textarea: label_above_textarea


### PR DESCRIPTION
* add id to theme test question
* remove no label question from theme test to not trigger "no label isn't accessible" error. Could be an argument for keeping it around and waiting for DAYamlChecker ignoring to be implemented, but we also shouldn't really be checking what no label fields look like, since we shouldn't use them on multi-field screens.